### PR TITLE
Allow to specify enabled components

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
 | Parameter | Description |
 | --------- | ----------- |
 | `dns ip`  | External DNS server IP to use in node-config.yaml |
+| `enable`  | A list of components to enable (comma separated) |
 | `github token` | GITHUB_TOKEN secret value to access GitHub REST API with an unlimited number of requests |
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,8 @@ inputs:
     required: true
   dns ip:
     description: 'External DNS server IP to use in node-config.yaml'
+  enable:
+    description: 'A list of components to enable (comma separated)'
   github token:
     description: 'GITHUB_TOKEN to be able to perform requests to GH REST API (with no limit)'
 runs:

--- a/src/__tests__/load-inputs.test.js
+++ b/src/__tests__/load-inputs.test.js
@@ -10,7 +10,8 @@ describe('load-inputs module test suite', () => {
       process.env = {
         INPUT_OC_VERSION: 'v1.33.7',
         INPUT_GITHUB_TOKEN: 'secret-token',
-        INPUT_DNS_IP: '1.3.3.7'
+        INPUT_DNS_IP: '1.3.3.7',
+        INPUT_ENABLE: 'centos-imagestreams,persistent-volumes,registry,router'
       };
       // When
       const result = loadInputs();
@@ -18,7 +19,8 @@ describe('load-inputs module test suite', () => {
       expect(result).toEqual({
         ocVersion: 'v1.33.7',
         githubToken: 'secret-token',
-        dnsIp: '1.3.3.7'
+        dnsIp: '1.3.3.7',
+        enable: 'centos-imagestreams,persistent-volumes,registry,router'
       });
     });
     test('Required variables NOT in env, should throw error', () => {

--- a/src/load-inputs.js
+++ b/src/load-inputs.js
@@ -8,6 +8,7 @@ const loadInputs = () => {
   result.ocVersion = core.getInput('oc version', {required: true});
   result.githubToken = core.getInput('github token');
   result.dnsIp = core.getInput('dns ip');
+  result.enable = core.getInput('enable');
   return result;
 };
 


### PR DESCRIPTION
When not all components are needed, we can disable some to save time and memory during execution.

`v1.0.5` output looks like this:
```
2020-08-03T14:50:06.2457501Z [command]/bin/tar xz --warning=no-unknown-keyword -C /home/runner/work/_temp/16574e3b-17db-405c-908e-9e032b09e131 -f /home/runner/work/_temp/0f0e8ce4-29d3-4b0f-9c4d-9cd26c205a84
2020-08-03T14:50:08.3118420Z Getting a Docker client ...
2020-08-03T14:50:08.3124486Z Checking if image openshift/origin-control-plane:v3.11 is available ...
2020-08-03T14:50:08.3129835Z Pulling image openshift/origin-control-plane:v3.11
2020-08-03T14:50:08.3134359Z E0803 14:50:08.313253    3641 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-control-plane:v3.11 anonymously
2020-08-03T14:50:08.8113934Z Pulled 2/5 layers, 44% complete
2020-08-03T14:50:09.2650983Z Pulled 3/5 layers, 77% complete
2020-08-03T14:50:09.2966778Z Pulled 4/5 layers, 86% complete
2020-08-03T14:50:09.8464438Z Pulled 5/5 layers, 100% complete
2020-08-03T14:50:09.8464641Z Extracting
2020-08-03T14:50:31.1826210Z Image pull complete
2020-08-03T14:50:31.1832185Z E0803 14:50:31.182942    3641 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-cli:v3.11 anonymously
2020-08-03T14:50:31.1832856Z Pulling image openshift/origin-cli:v3.11
2020-08-03T14:50:31.4840090Z E0803 14:50:31.483478    3641 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-node:v3.11 anonymously
2020-08-03T14:50:31.4840710Z Image pull complete
2020-08-03T14:50:31.4841130Z Pulling image openshift/origin-node:v3.11
2020-08-03T14:50:32.5783426Z Pulled 6/6 layers, 100% complete
2020-08-03T14:50:32.5783654Z Extracting
2020-08-03T14:50:41.8495480Z Image pull complete
2020-08-03T14:50:41.8555057Z Creating shared mount directory on the remote host ...
2020-08-03T14:50:53.7993406Z Determining server IP ...
2020-08-03T14:50:55.2348150Z Checking if OpenShift is already running ...
2020-08-03T14:50:55.2360678Z Checking for supported Docker version (=>1.22) ...
2020-08-03T14:50:55.2436909Z Checking if insecured registry is configured properly in Docker ...
2020-08-03T14:50:55.2437351Z Checking if required ports are available ...
2020-08-03T14:50:55.7811459Z Checking if OpenShift client is configured properly ...
2020-08-03T14:50:55.7812497Z Checking if image openshift/origin-control-plane:v3.11 is available ...
2020-08-03T14:50:55.7842983Z I0803 14:50:55.784103    3641 config.go:40] Running "create-master-config"
2020-08-03T14:50:55.7843396Z Starting OpenShift using openshift/origin-control-plane:v3.11 ...
2020-08-03T14:50:59.2291089Z I0803 14:50:59.228872    3641 config.go:46] Running "create-node-config"
2020-08-03T14:51:00.4457313Z I0803 14:51:00.445484    3641 flags.go:30] Running "create-kubelet-flags"
2020-08-03T14:51:01.2331254Z I0803 14:51:01.232844    3641 run_kubelet.go:49] Running "start-kubelet"
2020-08-03T14:51:01.5404838Z I0803 14:51:01.540155    3641 run_self_hosted.go:181] Waiting for the kube-apiserver to be ready ...
2020-08-03T14:51:37.5627444Z I0803 14:51:37.562481    3641 interface.go:26] Installing "kube-proxy" ...
2020-08-03T14:51:37.5628404Z I0803 14:51:37.562516    3641 interface.go:26] Installing "kube-dns" ...
2020-08-03T14:51:37.5628956Z I0803 14:51:37.562522    3641 interface.go:26] Installing "openshift-service-cert-signer-operator" ...
2020-08-03T14:51:37.5629542Z I0803 14:51:37.562528    3641 interface.go:26] Installing "openshift-apiserver" ...
2020-08-03T14:51:37.5630232Z I0803 14:51:37.562550    3641 apply_template.go:81] Installing "openshift-apiserver"
2020-08-03T14:51:37.5630854Z I0803 14:51:37.562717    3641 apply_template.go:81] Installing "kube-proxy"
2020-08-03T14:51:37.5631521Z I0803 14:51:37.562882    3641 apply_template.go:81] Installing "kube-dns"
2020-08-03T14:51:37.5632146Z I0803 14:51:37.562992    3641 apply_template.go:81] Installing "openshift-service-cert-signer-operator"
2020-08-03T14:51:42.1968561Z I0803 14:51:42.196499    3641 interface.go:41] Finished installing "kube-proxy" "kube-dns" "openshift-service-cert-signer-operator" "openshift-apiserver"
2020-08-03T14:53:12.2656778Z I0803 14:53:12.265060    3641 run_self_hosted.go:242] openshift-apiserver available
2020-08-03T14:53:12.2657227Z I0803 14:53:12.265138    3641 interface.go:26] Installing "openshift-controller-manager" ...
2020-08-03T14:53:12.2657607Z I0803 14:53:12.265155    3641 apply_template.go:81] Installing "openshift-controller-manager"
2020-08-03T14:53:16.0019758Z I0803 14:53:15.999945    3641 interface.go:41] Finished installing "openshift-controller-manager"
2020-08-03T14:53:16.0099879Z Adding default OAuthClient redirect URIs ...
2020-08-03T14:53:16.0203663Z I0803 14:53:16.020175    3641 interface.go:26] Installing "openshift-router" ...
2020-08-03T14:53:16.0203875Z Adding router ...
2020-08-03T14:53:16.0249716Z I0803 14:53:16.020192    3641 interface.go:26] Installing "openshift-image-registry" ...
2020-08-03T14:53:16.0249902Z Adding registry ...
2020-08-03T14:53:16.0253917Z I0803 14:53:16.020198    3641 interface.go:26] Installing "sample-templates" ...
2020-08-03T14:53:16.0254233Z Adding sample-templates ...
2020-08-03T14:53:16.0275160Z I0803 14:53:16.020203    3641 interface.go:26] Installing "persistent-volumes" ...
2020-08-03T14:53:16.0277579Z Adding persistent-volumes ...
2020-08-03T14:53:16.0280415Z I0803 14:53:16.020210    3641 interface.go:26] Installing "openshift-web-console-operator" ...
2020-08-03T14:53:16.0280711Z Adding web-console ...
2020-08-03T14:53:16.0292895Z I0803 14:53:16.020215    3641 interface.go:26] Installing "centos-imagestreams" ...
2020-08-03T14:53:16.0293266Z Adding centos-imagestreams ...
2020-08-03T14:53:16.0296719Z I0803 14:53:16.020259    3641 apply_list.go:67] Installing "centos-imagestreams"
2020-08-03T14:53:16.0298328Z I0803 14:53:16.020985    3641 interface.go:26] Installing "sample-templates/mongodb" ...
2020-08-03T14:53:16.0300843Z I0803 14:53:16.020994    3641 interface.go:26] Installing "sample-templates/mariadb" ...
2020-08-03T14:53:16.0301657Z I0803 14:53:16.020999    3641 interface.go:26] Installing "sample-templates/cakephp quickstart" ...
2020-08-03T14:53:16.0305026Z I0803 14:53:16.021006    3641 interface.go:26] Installing "sample-templates/dancer quickstart" ...
2020-08-03T14:53:16.0306746Z I0803 14:53:16.021011    3641 interface.go:26] Installing "sample-templates/nodejs quickstart" ...
2020-08-03T14:53:16.0309322Z I0803 14:53:16.021016    3641 interface.go:26] Installing "sample-templates/rails quickstart" ...
2020-08-03T14:53:16.0310608Z I0803 14:53:16.021021    3641 interface.go:26] Installing "sample-templates/jenkins pipeline ephemeral" ...
2020-08-03T14:53:16.0312934Z I0803 14:53:16.021027    3641 interface.go:26] Installing "sample-templates/mysql" ...
2020-08-03T14:53:16.0315242Z I0803 14:53:16.021032    3641 interface.go:26] Installing "sample-templates/postgresql" ...
2020-08-03T14:53:16.0316810Z I0803 14:53:16.021037    3641 interface.go:26] Installing "sample-templates/django quickstart" ...
2020-08-03T14:53:16.0319624Z I0803 14:53:16.021042    3641 interface.go:26] Installing "sample-templates/sample pipeline" ...
2020-08-03T14:53:16.0321173Z I0803 14:53:16.021083    3641 apply_list.go:67] Installing "sample-templates/sample pipeline"
2020-08-03T14:53:16.0323541Z I0803 14:53:16.021948    3641 apply_template.go:81] Installing "openshift-web-console-operator"
2020-08-03T14:53:16.0325027Z I0803 14:53:16.022123    3641 apply_list.go:67] Installing "sample-templates/mongodb"
2020-08-03T14:53:16.0425903Z I0803 14:53:16.022259    3641 apply_list.go:67] Installing "sample-templates/mariadb"
2020-08-03T14:53:16.0430885Z I0803 14:53:16.028333    3641 apply_list.go:67] Installing "sample-templates/cakephp quickstart"
2020-08-03T14:53:16.0431520Z I0803 14:53:16.028492    3641 apply_list.go:67] Installing "sample-templates/dancer quickstart"
2020-08-03T14:53:16.0433990Z I0803 14:53:16.028597    3641 apply_list.go:67] Installing "sample-templates/nodejs quickstart"
2020-08-03T14:53:16.0434751Z I0803 14:53:16.028712    3641 apply_list.go:67] Installing "sample-templates/rails quickstart"
2020-08-03T14:53:16.0439352Z I0803 14:53:16.028826    3641 apply_list.go:67] Installing "sample-templates/jenkins pipeline ephemeral"
2020-08-03T14:53:16.0440080Z I0803 14:53:16.028924    3641 apply_list.go:67] Installing "sample-templates/mysql"
2020-08-03T14:53:16.0440590Z I0803 14:53:16.029040    3641 apply_list.go:67] Installing "sample-templates/postgresql"
2020-08-03T14:53:16.0442172Z I0803 14:53:16.029133    3641 apply_list.go:67] Installing "sample-templates/django quickstart"
2020-08-03T14:53:36.2470809Z I0803 14:53:36.246630    3641 interface.go:41] Finished installing "sample-templates/mongodb" "sample-templates/mariadb" "sample-templates/cakephp quickstart" "sample-templates/dancer quickstart" "sample-templates/nodejs quickstart" "sample-templates/rails quickstart" "sample-templates/jenkins pipeline ephemeral" "sample-templates/mysql" "sample-templates/postgresql" "sample-templates/django quickstart" "sample-templates/sample pipeline"
2020-08-03T14:54:17.0742176Z I0803 14:54:16.439599    3641 interface.go:41] Finished installing "openshift-router" "openshift-image-registry" "sample-templates" "persistent-volumes" "openshift-web-console-operator" "centos-imagestreams"
```

Output from this branch (with `enable: 'centos-imagestreams,persistent-volumes,registry,router'`, see https://github.com/opendevstack/tailor/runs/943797320):
```
2020-08-04T07:29:50.3581351Z [command]/bin/tar xz --warning=no-unknown-keyword -C /home/runner/work/_temp/70b21ad9-7b2e-4b15-b538-562936774389 -f /home/runner/work/_temp/3775b9bb-1747-4d4d-8270-7056a8b96ca4
2020-08-04T07:29:52.2410036Z Starting cluster with: oc cluster up --routing-suffix="127.0.0.1.${OC_DOMAIN:-nip.io}" --enable=centos-imagestreams --enable=persistent-volumes --enable=registry --enable=router
2020-08-04T07:29:52.4004332Z Getting a Docker client ...
2020-08-04T07:29:52.4012179Z Checking if image openshift/origin-control-plane:v3.11 is available ...
2020-08-04T07:29:52.4012959Z Pulling image openshift/origin-control-plane:v3.11
2020-08-04T07:29:52.4013997Z E0804 07:29:52.400481    3488 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-control-plane:v3.11 anonymously
2020-08-04T07:29:52.8608193Z Pulled 2/5 layers, 40% complete
2020-08-04T07:29:53.1515912Z Pulled 3/5 layers, 70% complete
2020-08-04T07:29:53.2896767Z Pulled 4/5 layers, 80% complete
2020-08-04T07:29:54.0818008Z Pulled 5/5 layers, 100% complete
2020-08-04T07:29:54.0818261Z Extracting
2020-08-04T07:30:03.7098692Z E0804 07:30:03.709488    3488 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-cli:v3.11 anonymously
2020-08-04T07:30:03.7099022Z Image pull complete
2020-08-04T07:30:03.7099425Z Pulling image openshift/origin-cli:v3.11
2020-08-04T07:30:05.3291102Z E0804 07:30:05.328035    3488 helper.go:179] Reading docker config from /home/runner/.docker/config.json failed: open /home/runner/.docker/config.json: no such file or directory, will attempt to pull image docker.io/openshift/origin-node:v3.11 anonymously
2020-08-04T07:30:05.3291482Z Image pull complete
2020-08-04T07:30:05.3291980Z Pulling image openshift/origin-node:v3.11
2020-08-04T07:30:06.3461902Z Pulled 6/6 layers, 100% complete
2020-08-04T07:30:06.3462398Z Extracting
2020-08-04T07:30:11.9687317Z Image pull complete
2020-08-04T07:30:11.9736503Z Creating shared mount directory on the remote host ...
2020-08-04T07:30:19.4148346Z Determining server IP ...
2020-08-04T07:30:19.8709154Z Checking if OpenShift is already running ...
2020-08-04T07:30:19.8709377Z Checking for supported Docker version (=>1.22) ...
2020-08-04T07:30:19.8827051Z Checking if insecured registry is configured properly in Docker ...
2020-08-04T07:30:19.8827277Z Checking if required ports are available ...
2020-08-04T07:30:20.0945975Z Checking if OpenShift client is configured properly ...
2020-08-04T07:30:20.0946804Z Checking if image openshift/origin-control-plane:v3.11 is available ...
2020-08-04T07:30:20.1015423Z I0804 07:30:20.097551    3488 config.go:40] Running "create-master-config"
2020-08-04T07:30:20.1015785Z Starting OpenShift using openshift/origin-control-plane:v3.11 ...
2020-08-04T07:30:22.4048199Z I0804 07:30:22.404506    3488 config.go:46] Running "create-node-config"
2020-08-04T07:30:23.4405312Z I0804 07:30:23.440230    3488 flags.go:30] Running "create-kubelet-flags"
2020-08-04T07:30:23.9154707Z I0804 07:30:23.915240    3488 run_kubelet.go:49] Running "start-kubelet"
2020-08-04T07:30:24.0503237Z I0804 07:30:24.050098    3488 run_self_hosted.go:181] Waiting for the kube-apiserver to be ready ...
2020-08-04T07:30:51.0646189Z I0804 07:30:51.064318    3488 interface.go:26] Installing "kube-proxy" ...
2020-08-04T07:30:51.0646648Z I0804 07:30:51.064344    3488 interface.go:26] Installing "kube-dns" ...
2020-08-04T07:30:51.0647056Z I0804 07:30:51.064351    3488 interface.go:26] Installing "openshift-service-cert-signer-operator" ...
2020-08-04T07:30:51.0647414Z I0804 07:30:51.064357    3488 interface.go:26] Installing "openshift-apiserver" ...
2020-08-04T07:30:51.0647772Z I0804 07:30:51.064377    3488 apply_template.go:81] Installing "openshift-apiserver"
2020-08-04T07:30:51.0649504Z I0804 07:30:51.064844    3488 apply_template.go:81] Installing "kube-dns"
2020-08-04T07:30:51.0652900Z I0804 07:30:51.065165    3488 apply_template.go:81] Installing "kube-proxy"
2020-08-04T07:30:51.0656829Z I0804 07:30:51.065555    3488 apply_template.go:81] Installing "openshift-service-cert-signer-operator"
2020-08-04T07:30:55.2143937Z I0804 07:30:55.211685    3488 interface.go:41] Finished installing "kube-proxy" "kube-dns" "openshift-service-cert-signer-operator" "openshift-apiserver"
2020-08-04T07:32:13.2448348Z I0804 07:32:13.244641    3488 run_self_hosted.go:242] openshift-apiserver available
2020-08-04T07:32:13.2452210Z I0804 07:32:13.245145    3488 interface.go:26] Installing "openshift-controller-manager" ...
2020-08-04T07:32:13.2474980Z I0804 07:32:13.247244    3488 apply_template.go:81] Installing "openshift-controller-manager"
2020-08-04T07:32:16.0648309Z I0804 07:32:16.063589    3488 interface.go:41] Finished installing "openshift-controller-manager"
2020-08-04T07:32:16.0888234Z Adding default OAuthClient redirect URIs ...
2020-08-04T07:32:16.1190181Z I0804 07:32:16.109206    3488 interface.go:26] Installing "centos-imagestreams" ...
2020-08-04T07:32:16.1190617Z I0804 07:32:16.109309    3488 interface.go:26] Installing "openshift-router" ...
2020-08-04T07:32:16.1190976Z I0804 07:32:16.109315    3488 interface.go:26] Installing "persistent-volumes" ...
2020-08-04T07:32:16.1191335Z I0804 07:32:16.109320    3488 interface.go:26] Installing "openshift-image-registry" ...
2020-08-04T07:32:16.1191684Z I0804 07:32:16.109695    3488 apply_list.go:67] Installing "centos-imagestreams"
2020-08-04T07:32:16.1218701Z Adding centos-imagestreams ...
2020-08-04T07:32:16.1314613Z Adding router ...
2020-08-04T07:32:16.1315171Z Adding persistent-volumes ...
2020-08-04T07:32:16.1315310Z Adding registry ...
2020-08-04T07:32:20.2177286Z I0804 07:32:20.216417    3488 interface.go:41] Finished installing "centos-imagestreams" "openshift-router" "persistent-volumes" "openshift-image-registry"
```