### PR TITLE
metadata: action uses Node 16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: NPM install

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -16,7 +16,7 @@ jobs:
         openshift: [v3.11.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: Test Action
@@ -36,7 +36,7 @@ jobs:
         openshift: [v3.11.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: Test Action
@@ -62,7 +62,7 @@ jobs:
         openshift: [v3.11.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: Test Action
@@ -85,7 +85,7 @@ jobs:
         openshift: [v3.9.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: Test Action
@@ -105,7 +105,7 @@ jobs:
         openshift: [v3.9.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@master
       - name: Test Action

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
   github token:
     description: 'GITHUB_TOKEN to be able to perform requests to GH REST API (with no limit)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'src/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/